### PR TITLE
Change "pypi" -> "PyPy"

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,9 +75,9 @@ function. Just like this:</p>
 <p>Forbidden Fruit runs on all cpython versions I tested so far, which includes
 the versions 2.5, 2.6, 2.7, 3.2 and 3.3. Since Forbidden Fruit is fundamentally
 dependent on the C API, this library won't work on other python
-implementations, such as Jython, pypi, etc.</p>
+implementations, such as Jython, PyPy, etc.</p>
 
-<p>I might add support for pypi in the future, but It's unlikely that I'll do it
+<p>I might add support for PyPy in the future, but It's unlikely that I'll do it
 for Jython. But I could happily accept patches for them.</p>
 
 <h2>License</h2>


### PR DESCRIPTION
PyPy is an implementation of Python; "pypi" is the Python Package Index.
