### PR TITLE
Fix usage of dir() without arg to inspect local scope

### DIFF
--- a/forbiddenfruit/__init__.py
+++ b/forbiddenfruit/__init__.py
@@ -1,4 +1,5 @@
 import ctypes
+import inspect
 from functools import wraps
 from collections import defaultdict
 
@@ -56,6 +57,11 @@ def patchable_builtin(klass):
 @wraps(__builtin__.dir)
 def __filtered_dir__(obj=None):
     name = hasattr(obj, '__name__') and obj.__name__ or obj.__class__.__name__
+    if obj is None:
+        # Return names from the local scope of the calling frame, taking into
+        # account indirection added by __filtered_dir__
+        calling_frame = inspect.currentframe().f_back
+        return sorted(calling_frame.f_locals.keys())
     return sorted(set(__dir__(obj)).difference(__hidden_elements__[name]))
 
 # Switching to the custom dir impl declared above

--- a/tests/unit/test_forbidden_fruit.py
+++ b/tests/unit/test_forbidden_fruit.py
@@ -146,3 +146,18 @@ def test_curses_decorator():
 
     # Then I see the `str` class was patched
     assert "lincoln".md_title() == "# Lincoln"
+
+
+def test_dir_without_args_returns_names_in_local_scope():
+    """dir() without arguments should return the names from the local scope
+    of the calling frame, taking into account any indirection added
+    by __filtered_dir__
+    """
+
+    # Given that I have a local scope with some names bound to values
+    z = 1
+    some_name = 42
+
+    # Then I see that `dir()` correctly returns a sorted list of those names
+    assert 'some_name' in dir()
+    assert dir() == sorted(locals().keys())


### PR DESCRIPTION
A call to `dir()` without arguments [is supposed to list the names in the local scope](https://docs.python.org/2/library/functions.html#dir).

Because `forbiddenfruit` [monkey patches `__builtin__.dir` with its own `__filtered_dir__`](https://github.com/clarete/forbiddenfruit/blob/59ecb062d0d82ddbeaadbdbfa9590d61978455cd/forbiddenfruit/__init__.py#L56-L64), an additional frame is present in the call stack, making CPythons [`_dir_locals_`](https://hg.python.org/cpython/file/2.7/Objects/object.c#l1788) access the wrong frame.

This breaks the use of `dir()` to inspect the local scope. I noticed this when a 3rd party module's star imports from the `pickle` module suddenly misbehaved: The `pickle` module first defines a [limited `__all__`](https://hg.python.org/cpython/file/2.7/Lib/pickle.py#l37), but then [later extends it using `dir()`](https://hg.python.org/cpython/file/2.7/Lib/pickle.py#l165), which failed as soon as we imported `forbiddenfruit` in our tests.

Example:

```python
>>> from pickle import *
>>> PERSID
'P'
```

Now with importing `forbiddenfruit` first:

```python
>>> import forbiddenfruit
>>> from pickle import *
>>> PERSID
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'PERSID' is not defined
```


This change makes `__filtered_dir__` account for that additional stack frame and return the names from the local scope of the actual calling frame.

Includes a simple test that was enough to demonstrate the erroneous behavior, and now passes.

