### PR TITLE
Add cursed() context manager/decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,37 @@ profiling](https://github.com/localstack/localstack/blob/e38eae0d1fe442924f4256d
 
 ## Tiny Example
 
-It basically allows you to patch built-in objects, declared in C
-through python. Just like this:
+It basically allows you to patch built-in objects, declared in C through
+python. Just like this:
 
 1. Add a new method to the `int` class:
+
 ```python
->>> from forbiddenfruit import curse
->>> def words_of_wisdom(self):
-...     return self * "blah "
->>> curse(int, "words_of_wisdom", words_of_wisdom)
->>> assert (2).words_of_wisdom() == "blah blah "
+from forbiddenfruit import curse
+
+
+def words_of_wisdom(self):
+    return self * "blah "
+
+
+curse(int, "words_of_wisdom", words_of_wisdom)
+
+assert (2).words_of_wisdom() == "blah blah "
 ```
-2. Add a `classmethod` to a built-in class
+
+2. Add a `classmethod` to the `str` class:
+
 ```python
->>> from forbiddenfruit import curse
->>> def hello(self):
-...     return "blah"
->>> curse(str, "hello", classmethod(hello))
->>> assert str.hello() == "blah"
+from forbiddenfruit import curse
+
+
+def hello(self):
+    return "blah"
+
+
+curse(str, "hello", classmethod(hello))
+
+assert str.hello() == "blah"
 ```
 
 ### Reversing a curse
@@ -45,12 +58,43 @@ If you want to free your object from a curse, you can use the `reverse()`
 function. Just like this:
 
 ```python
->>> from forbiddenfruit import curse, reverse
->>> curse(str, "test", "blah")
->>> assert 'test' in dir(str)
->>> # Time to reverse the curse
->>> reverse(str, "test")
->>> assert 'test' not in dir(str)
+from forbiddenfruit import curse, reverse
+
+curse(str, "test", "blah")
+assert 'test' in dir(str)
+
+# Time to reverse the curse
+reverse(str, "test")
+assert 'test' not in dir(str)
+```
+
+**Beware:** `reverse()` only deletes attributes. If you `curse()`'d to replace
+a pre-existing attribute, `reverse()` won't re-install the existing attribute.
+
+### Context Manager / Decorator
+
+`cursed()` acts as a context manager to make a `curse()`, and then `reverse()`
+it on exit. It uses
+[`contextlib.contextmanager()`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager),
+so on Python 3.2+ it can also be used as a function decorator. Like so:
+
+```python
+from forbiddenfruit import cursed
+
+with cursed(str, "test", "blah"):
+    assert str.test == "blah"
+
+assert "test" not in dir(str)
+
+
+@cursed(str, "test", "blah")
+def function():
+    assert str.test == "blah"
+
+
+function()
+
+assert "test" not in dir(str)
 ```
 
 ## Compatibility

--- a/forbiddenfruit/__init__.py
+++ b/forbiddenfruit/__init__.py
@@ -46,6 +46,7 @@ import ctypes
 import inspect
 from functools import wraps
 from collections import defaultdict
+from contextlib import contextmanager
 
 try:
     import __builtin__
@@ -514,3 +515,12 @@ def curses(klass, name):
         curse(klass, name, func)
         return func
     return wrapper
+
+
+@contextmanager
+def cursed(obj, attr, val, hide_from_dir=False):
+    curse(obj, attr, val, hide_from_dir)
+    try:
+        yield
+    finally:
+        reverse(obj, attr)

--- a/tests/unit/test_forbidden_fruit.py
+++ b/tests/unit/test_forbidden_fruit.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime
-from forbiddenfruit import curses, curse, reverse
+from forbiddenfruit import cursed, curses, curse, reverse
 from types import FunctionType
 from nose.tools import nottest, istest
 
@@ -330,3 +330,39 @@ def test_dunder_reverse():
 
     reverse(TypeError, '__str__')
     assert str(te) == "testing"
+
+
+def test_cursed_context_manager():
+    "The `cursed` context manager should curse an existing symbols in a scope"
+
+    # Given that I have an instance of a python class
+    obj = {'a': 1, 'b': 2}
+
+    # When I curse an instance method
+    with cursed(dict, "open_box", lambda self: 'surprise'):
+        # Then I see that my object was cursed properly
+        assert obj.open_box() == 'surprise'
+
+    # And it was reversed
+    assert "open_box" not in dir(obj)
+    assert "open_box" not in dir(dict)
+
+
+@skip_legacy
+def test_cursed_decorator():
+    "The `cursed` decorator should curse an existing symbols during a function"
+
+    # Given that I have an instance of a python class
+    obj = {'a': 1, 'b': 2}
+
+    # When I curse an instance method using the decorator form of `cursed`
+    @cursed(dict, "open_box", lambda self: 'surprise')
+    def function():
+        # Then I see that my object was cursed properly
+        assert obj.open_box() == 'surprise'
+
+    function()
+
+    # And it was reversed
+    assert "open_box" not in dir(obj)
+    assert "open_box" not in dir(dict)


### PR DESCRIPTION
Revival of #16. I think the failures experienced in the past were due to replacing `dict.values()`. Since `reverse()` doesn't undo replacements but just deletes attributes, a dict without `.values()` would crash Python.

This PR also reworks the README to use code snippets rather than the repl, since it's not possible to type `with` or `def` statements into the REPL.