### PR TITLE
Include COPYING.mit in distributed packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include COPYING
+include COPYING.mit
 include requirements.txt
 graft tests


### PR DESCRIPTION
While the library is dual-licensed, only the GPLv3 file was included in
sdist and wheels. This change adds COPYING.mit to MANIFEST.in to ensure
it ends up in the packages.