### PR TITLE
Add support for cursing __new__

### DIFF
--- a/forbiddenfruit/__init__.py
+++ b/forbiddenfruit/__init__.py
@@ -205,7 +205,29 @@ PyTypeObject._fields_ = [
     ('tp_hash', ctypes.CFUNCTYPE(ctypes.c_int64, PyObject_p)),
     ('tp_call', ctypes.CFUNCTYPE(PyObject_p, PyObject_p, PyObject_p, PyObject_p)),
     ('tp_str', ctypes.CFUNCTYPE(PyObject_p, PyObject_p)),
-    # ...
+    ('tp_getattro', ctypes.c_void_p),  # Type not declared yet
+    ('tp_setattro', ctypes.c_void_p),  # Type not declared yet
+    ('tp_as_buffer', ctypes.c_void_p),  # Type not declared yet
+    ('tp_flags', ctypes.c_void_p),  # Type not declared yet
+    ('tp_doc', ctypes.c_void_p),  # Type not declared yet
+    ('tp_traverse', ctypes.c_void_p),  # Type not declared yet
+    ('tp_clear', ctypes.c_void_p),  # Type not declared yet
+    ('tp_richcompare', ctypes.c_void_p),  # Type not declared yet
+    ('tp_weaklistoffset', ctypes.c_void_p),  # Type not declared yet
+    ('tp_iter', ctypes.c_void_p),  # Type not declared yet
+    ('iternextfunc', ctypes.c_void_p),  # Type not declared yet
+    ('tp_methods', ctypes.c_void_p),  # Type not declared yet
+    ('tp_members', ctypes.c_void_p),  # Type not declared yet
+    ('tp_getset', ctypes.c_void_p),  # Type not declared yet
+    ('tp_base', ctypes.c_void_p),  # Type not declared yet
+    ('tp_dict', ctypes.c_void_p),  # Type not declared yet
+    ('tp_descr_get', ctypes.c_void_p),  # Type not declared yet
+    ('tp_descr_set', ctypes.c_void_p),  # Type not declared yet
+    ('tp_dictoffset', ctypes.c_void_p),  # Type not declared yet
+    ('tp_init', ctypes.c_void_p),  # Type not declared yet
+    ('tp_alloc', ctypes.c_void_p),  # Type not declared yet
+    ('tp_new', ctypes.CFUNCTYPE(PyObject_p, PyObject_p, PyObject_p, ctypes.c_void_p)),
+    # More struct fields follow but aren't declared here yet ...
 ]
 
 
@@ -305,6 +327,7 @@ for override in [as_number, as_sequence, as_async]:
 # divmod isn't a dunder, still make it overridable
 override_dict['divmod()'] = ('tp_as_number', "nb_divmod")
 override_dict['__str__'] = ('tp_str', "tp_str")
+override_dict['__new__'] = ('tp_new', "tp_new")
 
 
 def _is_dunder(func_name):

--- a/tests/unit/test_forbidden_fruit.py
+++ b/tests/unit/test_forbidden_fruit.py
@@ -319,6 +319,7 @@ def test_dunder_str():
         return 'one'
     curse(int, '__str__', always_one)
     assert str(1) == "one"
+    reverse(int, '__str__')
 
 @skip_legacy
 def test_dunder_reverse():
@@ -331,6 +332,15 @@ def test_dunder_reverse():
     reverse(TypeError, '__str__')
     assert str(te) == "testing"
 
+@skip_legacy
+def test_dunder_new():
+    assert str(1) == "1"
+    def the_answer(cls, args, kwargs):
+        return 'fourty-two'
+    curse(str, '__new__', the_answer)
+    assert str(1) == "fourty-two"
+    reverse(str, '__new__')
+    assert str(1) == "1"
 
 def test_cursed_context_manager():
     "The `cursed` context manager should curse an existing symbols in a scope"


### PR DESCRIPTION
Somewhat related to #38

Sadly, I only know enough about ctypes/CPython to be dangerous, so looking for guidance on this one.

I'm not sure how ugly it is to leave placeholders in the structure declaration. Some of those probably aren't even pointers but just happen to have the right size.

Finally, the final "kwargs" argument to [tp_new](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_new) is declared as a void pointer: I think it is supposed to be a PyObject_p, but Python passes NULL in there sometimes (when no kwargs are present?), and ctypes raises `ValueError: PyObject is NULL` in that case.
