### PR TITLE
Added support for __hash__

### DIFF
--- a/forbiddenfruit/__init__.py
+++ b/forbiddenfruit/__init__.py
@@ -328,6 +328,8 @@ for override in [as_number, as_sequence, as_async]:
 override_dict['divmod()'] = ('tp_as_number', "nb_divmod")
 override_dict['__str__'] = ('tp_str', "tp_str")
 override_dict['__new__'] = ('tp_new', "tp_new")
+override_dict['__hash__'] = ('tp_hash', "tp_hash")
+
 
 
 def _is_dunder(func_name):


### PR DESCRIPTION
Tiny change to override_dict to allow overriding `__hash__(self)` magic method

Can be verified by running following code:

```
import forbiddenfruit
hashLambda = lambda obj: id(obj)
forbiddenfruit.curse(set, "__hash__", hashLambda)

baseSet = {"a", "b"}
outerSet = {baseSet, 24} # set now contains another set object, using its id in memory as its hash
```