### PR TITLE
Support cursing `__next__`

### DIFF
--- a/forbiddenfruit/__init__.py
+++ b/forbiddenfruit/__init__.py
@@ -215,7 +215,7 @@ PyTypeObject._fields_ = [
     ('tp_richcompare', ctypes.c_void_p),  # Type not declared yet
     ('tp_weaklistoffset', ctypes.c_void_p),  # Type not declared yet
     ('tp_iter', ctypes.c_void_p),  # Type not declared yet
-    ('iternextfunc', ctypes.c_void_p),  # Type not declared yet
+    ('tp_iternext', ctypes.CFUNCTYPE(PyObject_p, PyObject_p)),
     ('tp_methods', ctypes.c_void_p),  # Type not declared yet
     ('tp_members', ctypes.c_void_p),  # Type not declared yet
     ('tp_getset', ctypes.c_void_p),  # Type not declared yet
@@ -329,6 +329,7 @@ override_dict['divmod()'] = ('tp_as_number', "nb_divmod")
 override_dict['__str__'] = ('tp_str', "tp_str")
 override_dict['__new__'] = ('tp_new', "tp_new")
 override_dict['__hash__'] = ('tp_hash', "tp_hash")
+override_dict['__next__'] = ('tp_iternext', "tp_iternext")
 
 
 

--- a/tests/unit/test_forbidden_fruit.py
+++ b/tests/unit/test_forbidden_fruit.py
@@ -342,6 +342,17 @@ def test_dunder_new():
     reverse(str, '__new__')
     assert str(1) == "1"
 
+@skip_legacy
+def test_dunder_next():
+    assert next(iter([1])) == 1
+    def the_answer(cls):
+        return 42
+    list_iterator = type(iter([]))
+    curse(list_iterator, '__next__', the_answer)
+    assert next(iter([1])) == 42
+    reverse(list_iterator, '__next__')
+    assert next(iter([1])) == 1
+
 def test_cursed_context_manager():
     "The `cursed` context manager should curse an existing symbols in a scope"
 


### PR DESCRIPTION
Follow-up from https://github.com/clarete/forbiddenfruit/pull/85

> Support cursing `__next__` and fill in `tp_iternext` description. This is needed to make [blockbuster](https://github.com/cbornet/blockbuster) work on Python 3.15.

Added a unit test.